### PR TITLE
Added DB type double (type B) + ability to convert from different encodings

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,12 @@ while ($record = $table->nextRecord()) {
 }
 ```
 
+If the data in DB is not in UTF8 you can specify encoding to convert from.
+
+``` php
+$table = new Table(dirname(__FILE__).'/test.dbf', null, 'CP1251');
+```
+
 Write Data
 =====
 ``` php

--- a/src/XBase/Record.php
+++ b/src/XBase/Record.php
@@ -1,18 +1,20 @@
-<?php 
+<?php
 
 namespace XBase;
 
-class Record 
+class Record
 {
-    const DBFFIELD_TYPE_MEMO = 'M';     // Memo type field.
-    const DBFFIELD_TYPE_CHAR = 'C';     // Character field.
+    const DBFFIELD_TYPE_MEMO = 'M';     // Memo type field
+    const DBFFIELD_TYPE_CHAR = 'C';     // Character field
+    const DBFFIELD_TYPE_DOUBLE = 'B';   // Double
     const DBFFIELD_TYPE_NUMERIC = 'N';  // Numeric
     const DBFFIELD_TYPE_FLOATING = 'F'; // Floating point
     const DBFFIELD_TYPE_DATE = 'D';     // Date
     const DBFFIELD_TYPE_LOGICAL = 'L';  // Logical - ? Y y N n T t F f (? when not initialized).
     const DBFFIELD_TYPE_DATETIME = 'T'; // DateTime
-    const DBFFIELD_TYPE_INDEX = 'I';    // Index 
+    const DBFFIELD_TYPE_INDEX = 'I';    // Index
     const DBFFIELD_IGNORE_0 = '0';      // ignore this field
+    const DBRECORD_ENCODING = 'UTF-8';  // Default encoding
 
     protected $zerodate = 0x253d8c;
     protected $table;
@@ -20,14 +22,17 @@ class Record
     protected $deleted;
     protected $inserted;
     protected $recordIndex;
-    
-    public function __construct(Table $table, $recordIndex, $rawData = false) 
+
+    public function __construct(Table $table, $recordIndex, $rawData = false)
     {
         $this->table = $table;
         $this->recordIndex = $recordIndex;
         $this->choppedData = array();
 
         if ($rawData && strlen($rawData) > 0) {
+            if ($this->table->getConvertFrom()) {
+                $rawData = iconv($this->table->getConvertFrom(), self::DBRECORD_ENCODING, $rawData);
+            }
             $this->inserted = false;
             $this->deleted = (ord($rawData[0]) != '32');
 
@@ -69,17 +74,17 @@ class Record
         return $this->table->getColumns();
     }
 
-    public function getColumn($name) 
+    public function getColumn($name)
     {
         return $this->table->getColumn($name);
     }
-    
-    public function getRecordIndex() 
+
+    public function getRecordIndex()
     {
         return $this->recordIndex;
     }
 
-    public function getString($columnName) 
+    public function getString($columnName)
     {
         $column = $this->table->getColumn($columnName);
 
@@ -100,7 +105,7 @@ class Record
         }
     }
 
-    public function forceGetString($columnName) 
+    public function forceGetString($columnName)
     {
         if (ord($this->choppedData[$columnName][0]) == '0') {
             return false;
@@ -113,6 +118,7 @@ class Record
     {
         switch ($column->getType()) {
             case self::DBFFIELD_TYPE_CHAR:return $this->getString($column->getName());
+            case self::DBFFIELD_TYPE_DOUBLE:return $this->getFloat($column->getName());
             case self::DBFFIELD_TYPE_DATE:return $this->getDate($column->getName());
             case self::DBFFIELD_TYPE_DATETIME:return $this->getDateTime($column->getName());
             case self::DBFFIELD_TYPE_FLOATING:return $this->getFloat($column->getName());
@@ -225,7 +231,7 @@ class Record
 
         return $ret;
     }
-    
+
     public function copyFrom($record)
     {
         $this->choppedData = $record->choppedData;
@@ -280,6 +286,9 @@ class Record
             case self::DBFFIELD_TYPE_CHAR:
                 $this->setString($columnObj, $value);
                 return false;
+            case self::DBFFIELD_TYPE_DOUBLE:
+                $this->setFloat($columnObj, $value);
+                return false;
             case self::DBFFIELD_TYPE_DATE:
                 $this->setDate($columnObj, $value);
                 return false;
@@ -301,7 +310,7 @@ class Record
             case self::DBFFIELD_IGNORE_0:
                 return false;
         }
-        
+
         trigger_error('cannot handle datatype' . $columnObj->getType(), E_USER_ERROR);
     }
 

--- a/src/XBase/Table.php
+++ b/src/XBase/Table.php
@@ -11,6 +11,7 @@ class Table
     protected $recordPos = -1;
     protected $deleteCount = 0;
     protected $record;
+    protected $convertFrom;
 
     public $version;
     public $modifyDate;
@@ -25,10 +26,11 @@ class Table
     public $backlist;
     public $foxpro;
 
-    public function __construct($tableName, $avaliableColumns = null)
+    public function __construct($tableName, $avaliableColumns = null, $convertFrom = null)
     {
         $this->tableName = $tableName;
         $this->avaliableColumns = $avaliableColumns;
+        $this->convertFrom = $convertFrom;
         $this->open();
     }
 
@@ -255,6 +257,11 @@ class Table
     public function getDeleteCount()
     {
         return $this->deleteCount;
+    }
+
+    public function getConvertFrom()
+    {
+        return $this->convertFrom;
     }
 
     protected function isOpen()


### PR DESCRIPTION
Some minor changes:

* added support for column type B (double)
* added 3rd option to Table constructor method to convert data from different encodings to UTF8


This will fix [problem](https://github.com/hisamu/php-xbase/issues/8)
