### PR TITLE
remove parameter to flush() causing warning on php 7

### DIFF
--- a/src/XBase/WritableTable.php
+++ b/src/XBase/WritableTable.php
@@ -144,8 +144,8 @@ class WritableTable extends Table
         if ($this->record->isInserted()) {
             $this->writeHeader();
         }
-        
-        flush($this->fp);
+
+        flush();
     }
 
     public function deleteRecord()
@@ -154,7 +154,7 @@ class WritableTable extends Table
         
         fseek($this->fp, $this->headerLength+($this->record->getRecordIndex()*$this->recordByteLength));
         fwrite($this->fp, "!");
-        flush($this->fp);
+        flush();
     }
 
     public function undeleteRecord()
@@ -163,7 +163,7 @@ class WritableTable extends Table
         
         fseek($this->fp, $this->headerLength+($this->record->getRecordIndex()*$this->recordByteLength));
         fwrite($this->fp, " ");
-        flush($this->fp);
+        flush();
     }
 
     public function pack()


### PR DESCRIPTION
Docs: http://php.net/manual/en/function.flush.php

This function call doesn't need any parameters. I'm not sure it's needed at all but I left it there anyway.

In php >7 the unneeded parameter causes a warning which is not nice. https://3v4l.org/Ov7H1