### PR TITLE
Fix floating point or big (>max signed integer) number for 'N' type.

### DIFF
--- a/src/XBase/Column.php
+++ b/src/XBase/Column.php
@@ -31,9 +31,6 @@ class Column
         $this->indexed = $indexed;
         $this->bytePos = $bytePos;
         $this->colIndex = $colIndex;
-        if ($type == Record::DBFFIELD_TYPE_NUMERIC && ($decimalCount > 0 || $length > 9)) {
-            $this->type = $type = Record::DBFFIELD_TYPE_NUMERIC_DOUBLE;
-        }
     }
 
     

--- a/src/XBase/Column.php
+++ b/src/XBase/Column.php
@@ -1,8 +1,8 @@
-<?php
+<?php 
 
 namespace XBase;
 
-class Column
+class Column 
 {
 
     public $name;
@@ -18,10 +18,10 @@ class Column
     protected $bytePos;
     protected $colIndex;
 
-    public function __construct($name, $type, $memAddress, $length, $decimalCount, $reserved1, $workAreaID, $reserved2, $setFields, $reserved3, $indexed, $colIndex, $bytePos)
+    public function __construct($name, $type, $memAddress, $length, $decimalCount, $reserved1, $workAreaID, $reserved2, $setFields, $reserved3, $indexed, $colIndex, $bytePos) 
     {
         $this->rawname = $name;
-        $this->name = (strpos($name, 0x00) !== false) ? substr($name, 0, strpos($name, 0x00)) : $name;
+        $this->name = (strpos($name, 0x00) !== false ) ? substr($name, 0, strpos($name, 0x00)) : $name;
         $this->type = $type;
         $this->memAddress = $memAddress;
         $this->length = $length;
@@ -31,84 +31,79 @@ class Column
         $this->indexed = $indexed;
         $this->bytePos = $bytePos;
         $this->colIndex = $colIndex;
-        //
         if ($type == Record::DBFFIELD_TYPE_NUMERIC && ($decimalCount > 0 || $length > 9)) {
             $this->type = $type = Record::DBFFIELD_TYPE_NUMERIC_DOUBLE;
         }
     }
 
-    public function getDecimalCount()
+    
+    public function getDecimalCount() 
     {
         return $this->decimalCount;
     }
-
-    public function isIndexed()
+    
+    public function isIndexed() 
     {
         return $this->indexed;
     }
-
-    public function getLength()
+    
+    public function getLength() 
     {
         return $this->length;
     }
-
-    public function getDataLength()
+    
+    public function getDataLength() 
     {
         switch ($this->type) {
-            case Record::DBFFIELD_TYPE_DATE :
-                return 8;
-            case Record::DBFFIELD_TYPE_DATETIME :
-                return 8;
-            case Record::DBFFIELD_TYPE_LOGICAL :
-                return 1;
-            case Record::DBFFIELD_TYPE_MEMO :
-                return 10;
-            default :
-                return $this->length;
+            case Record::DBFFIELD_TYPE_DATE : return 8;
+            case Record::DBFFIELD_TYPE_DATETIME : return 8;
+            case Record::DBFFIELD_TYPE_LOGICAL : return 1;
+            case Record::DBFFIELD_TYPE_MEMO : return 10;
+            default : return $this->length;
         }
     }
-
-    public function getMemAddress()
+    
+    public function getMemAddress() 
     {
         return $this->memAddress;
     }
-
-    public function getName()
+    
+    public function getName() 
     {
         return $this->name;
     }
-
-    public function isSetFields()
+    
+    public function isSetFields() 
     {
         return $this->setFields;
     }
-
-    public function getType()
+    
+    public function getType() 
     {
         return $this->type;
     }
-
-    public function getWorkAreaID()
+    
+    public function getWorkAreaID() 
     {
         return $this->workAreaID;
     }
-
-    public function toString()
+    
+    public function toString() 
     {
         return $this->name;
     }
-
-    public function getBytePos()
+    
+    public function getBytePos() 
     {
         return $this->bytePos;
     }
-
-    public function getRawname()
+    
+    public function getRawname() 
     {
         return $this->rawname;
     }
-
-    public function getColIndex()
+    
+    public function getColIndex() 
     {
         return $this->colIndex;
     }

--- a/src/XBase/Column.php
+++ b/src/XBase/Column.php
@@ -1,8 +1,8 @@
-<?php 
+<?php
 
 namespace XBase;
 
-class Column 
+class Column
 {
 
     public $name;
@@ -18,10 +18,10 @@ class Column
     protected $bytePos;
     protected $colIndex;
 
-    public function __construct($name, $type, $memAddress, $length, $decimalCount, $reserved1, $workAreaID, $reserved2, $setFields, $reserved3, $indexed, $colIndex, $bytePos) 
+    public function __construct($name, $type, $memAddress, $length, $decimalCount, $reserved1, $workAreaID, $reserved2, $setFields, $reserved3, $indexed, $colIndex, $bytePos)
     {
         $this->rawname = $name;
-        $this->name = (strpos($name, 0x00) !== false ) ? substr($name, 0, strpos($name, 0x00)) : $name;
+        $this->name = (strpos($name, 0x00) !== false) ? substr($name, 0, strpos($name, 0x00)) : $name;
         $this->type = $type;
         $this->memAddress = $memAddress;
         $this->length = $length;
@@ -31,76 +31,84 @@ class Column
         $this->indexed = $indexed;
         $this->bytePos = $bytePos;
         $this->colIndex = $colIndex;
+        //
+        if ($type == Record::DBFFIELD_TYPE_NUMERIC && ($decimalCount > 0 || $length > 9)) {
+            $this->type = $type = Record::DBFFIELD_TYPE_NUMERIC_DOUBLE;
+        }
     }
 
-    
-    public function getDecimalCount() 
+    public function getDecimalCount()
     {
         return $this->decimalCount;
     }
-    
-    public function isIndexed() 
+
+    public function isIndexed()
     {
         return $this->indexed;
     }
-    
-    public function getLength() 
+
+    public function getLength()
     {
         return $this->length;
     }
-    
-    public function getDataLength() 
+
+    public function getDataLength()
     {
         switch ($this->type) {
-            case Record::DBFFIELD_TYPE_DATE : return 8;
-            case Record::DBFFIELD_TYPE_DATETIME : return 8;
-            case Record::DBFFIELD_TYPE_LOGICAL : return 1;
-            case Record::DBFFIELD_TYPE_MEMO : return 10;
-            default : return $this->length;
+            case Record::DBFFIELD_TYPE_DATE :
+                return 8;
+            case Record::DBFFIELD_TYPE_DATETIME :
+                return 8;
+            case Record::DBFFIELD_TYPE_LOGICAL :
+                return 1;
+            case Record::DBFFIELD_TYPE_MEMO :
+                return 10;
+            default :
+                return $this->length;
         }
     }
-    
-    public function getMemAddress() 
+
+    public function getMemAddress()
     {
         return $this->memAddress;
     }
-    
-    public function getName() 
+
+    public function getName()
     {
         return $this->name;
     }
-    
-    public function isSetFields() 
+
+    public function isSetFields()
     {
         return $this->setFields;
     }
-    
-    public function getType() 
+
+    public function getType()
     {
         return $this->type;
     }
-    
-    public function getWorkAreaID() 
+
+    public function getWorkAreaID()
     {
         return $this->workAreaID;
     }
-    
-    public function toString() 
+
+    public function toString()
     {
         return $this->name;
     }
-    
-    public function getBytePos() 
+
+    public function getBytePos()
     {
         return $this->bytePos;
     }
-    
-    public function getRawname() 
+
+    public function getRawname()
     {
         return $this->rawname;
     }
-    
-    public function getColIndex() 
+
+    public function getColIndex()
     {
         return $this->colIndex;
     }

--- a/src/XBase/Record.php
+++ b/src/XBase/Record.php
@@ -227,7 +227,13 @@ class Record
 
         $s = str_replace(',', '.', $s);
 
-        return intval($s);
+        /**
+         * @TODO: fix it in Table
+         */
+        if (($res = intval($s)) != $s) {
+            $res = doubleval($s);
+        }
+        return $res;
     }
 
     public function getIndex($columnName, $length)

--- a/src/XBase/Record.php
+++ b/src/XBase/Record.php
@@ -4,19 +4,17 @@ namespace XBase;
 
 class Record
 {
-    const DBFFIELD_TYPE_MEMO = 'M';     // Memo type field
-    const DBFFIELD_TYPE_CHAR = 'C';     // Character field
-    const DBFFIELD_TYPE_DOUBLE = 'B';   // Double
-    const DBFFIELD_TYPE_NUMERIC = 'N';  // Numeric
-
+    const DBFFIELD_TYPE_MEMO = 'M';             // Memo type field
+    const DBFFIELD_TYPE_CHAR = 'C';             // Character field
+    const DBFFIELD_TYPE_DOUBLE = 'B';           // Double
+    const DBFFIELD_TYPE_NUMERIC = 'N';          // Numeric
     const DBFFIELD_TYPE_NUMERIC_DOUBLE = 'ND';  // Numeric double
-
-    const DBFFIELD_TYPE_FLOATING = 'F'; // Floating point
-    const DBFFIELD_TYPE_DATE = 'D';     // Date
-    const DBFFIELD_TYPE_LOGICAL = 'L';  // Logical - ? Y y N n T t F f (? when not initialized).
-    const DBFFIELD_TYPE_DATETIME = 'T'; // DateTime
-    const DBFFIELD_TYPE_INDEX = 'I';    // Index
-    const DBFFIELD_IGNORE_0 = '0';      // ignore this field
+    const DBFFIELD_TYPE_FLOATING = 'F';         // Floating point
+    const DBFFIELD_TYPE_DATE = 'D';             // Date
+    const DBFFIELD_TYPE_LOGICAL = 'L';          // Logical - ? Y y N n T t F f (? when not initialized).
+    const DBFFIELD_TYPE_DATETIME = 'T';         // DateTime
+    const DBFFIELD_TYPE_INDEX = 'I';            // Index
+    const DBFFIELD_IGNORE_0 = '0';              // ignore this field
 
     protected $zerodate = 0x253d8c;
     protected $table;
@@ -246,7 +244,6 @@ class Record
 
         return doubleval($s);
     }
-
 
     public function getIndex($columnName, $length)
     {

--- a/src/XBase/Record.php
+++ b/src/XBase/Record.php
@@ -8,6 +8,9 @@ class Record
     const DBFFIELD_TYPE_CHAR = 'C';     // Character field
     const DBFFIELD_TYPE_DOUBLE = 'B';   // Double
     const DBFFIELD_TYPE_NUMERIC = 'N';  // Numeric
+
+    const DBFFIELD_TYPE_NUMERIC_DOUBLE = 'ND';  // Numeric double
+
     const DBFFIELD_TYPE_FLOATING = 'F'; // Floating point
     const DBFFIELD_TYPE_DATE = 'D';     // Date
     const DBFFIELD_TYPE_LOGICAL = 'L';  // Logical - ? Y y N n T t F f (? when not initialized).
@@ -127,6 +130,7 @@ class Record
             case self::DBFFIELD_TYPE_LOGICAL:return $this->getBoolean($column->getName());
             case self::DBFFIELD_TYPE_MEMO:return $this->getMemo($column->getName());
             case self::DBFFIELD_TYPE_NUMERIC:return $this->getInt($column->getName());
+            case self::DBFFIELD_TYPE_NUMERIC_DOUBLE: return $this->getNumbericDouble($column->getName());
             case self::DBFFIELD_TYPE_INDEX:return $this->getIndex($column->getName(), $column->getLength());
             case self::DBFFIELD_IGNORE_0:return false;
         }
@@ -227,14 +231,22 @@ class Record
 
         $s = str_replace(',', '.', $s);
 
-        /**
-         * @TODO: fix it in Table
-         */
-        if (($res = intval($s)) != $s) {
-            $res = doubleval($s);
-        }
-        return $res;
+        return intval($s);
     }
+
+    public function getNumbericDouble($columnName)
+    {
+        $s = $this->forceGetString($columnName);
+
+        if (!$s) {
+            return false;
+        }
+
+        $s = str_replace(',', '.', $s);
+
+        return doubleval($s);
+    }
+
 
     public function getIndex($columnName, $length)
     {

--- a/src/XBase/Record.php
+++ b/src/XBase/Record.php
@@ -4,17 +4,16 @@ namespace XBase;
 
 class Record
 {
-    const DBFFIELD_TYPE_MEMO = 'M';             // Memo type field
-    const DBFFIELD_TYPE_CHAR = 'C';             // Character field
-    const DBFFIELD_TYPE_DOUBLE = 'B';           // Double
-    const DBFFIELD_TYPE_NUMERIC = 'N';          // Numeric
-    const DBFFIELD_TYPE_NUMERIC_DOUBLE = 'ND';  // Numeric double
-    const DBFFIELD_TYPE_FLOATING = 'F';         // Floating point
-    const DBFFIELD_TYPE_DATE = 'D';             // Date
-    const DBFFIELD_TYPE_LOGICAL = 'L';          // Logical - ? Y y N n T t F f (? when not initialized).
-    const DBFFIELD_TYPE_DATETIME = 'T';         // DateTime
-    const DBFFIELD_TYPE_INDEX = 'I';            // Index
-    const DBFFIELD_IGNORE_0 = '0';              // ignore this field
+    const DBFFIELD_TYPE_MEMO = 'M';     // Memo type field
+    const DBFFIELD_TYPE_CHAR = 'C';     // Character field
+    const DBFFIELD_TYPE_DOUBLE = 'B';   // Double
+    const DBFFIELD_TYPE_NUMERIC = 'N';  // Numeric
+    const DBFFIELD_TYPE_FLOATING = 'F'; // Floating point
+    const DBFFIELD_TYPE_DATE = 'D';     // Date
+    const DBFFIELD_TYPE_LOGICAL = 'L';  // Logical - ? Y y N n T t F f (? when not initialized).
+    const DBFFIELD_TYPE_DATETIME = 'T'; // DateTime
+    const DBFFIELD_TYPE_INDEX = 'I';    // Index
+    const DBFFIELD_IGNORE_0 = '0';      // ignore this field
 
     protected $zerodate = 0x253d8c;
     protected $table;
@@ -127,8 +126,7 @@ class Record
             case self::DBFFIELD_TYPE_FLOATING:return $this->getFloat($column->getName());
             case self::DBFFIELD_TYPE_LOGICAL:return $this->getBoolean($column->getName());
             case self::DBFFIELD_TYPE_MEMO:return $this->getMemo($column->getName());
-            case self::DBFFIELD_TYPE_NUMERIC:return $this->getInt($column->getName());
-            case self::DBFFIELD_TYPE_NUMERIC_DOUBLE: return $this->getNumbericDouble($column->getName());
+            case self::DBFFIELD_TYPE_NUMERIC:return $this->getNum($column->getName());
             case self::DBFFIELD_TYPE_INDEX:return $this->getIndex($column->getName(), $column->getLength());
             case self::DBFFIELD_IGNORE_0:return false;
         }
@@ -219,7 +217,7 @@ class Record
         return 0;
     }
 
-    public function getInt($columnName)
+    public function getNum($columnName)
     {
         $s = $this->forceGetString($columnName);
 
@@ -229,20 +227,9 @@ class Record
 
         $s = str_replace(',', '.', $s);
 
-        return intval($s);
-    }
-
-    public function getNumbericDouble($columnName)
-    {
-        $s = $this->forceGetString($columnName);
-
-        if (!$s) {
-            return false;
-        }
-
-        $s = str_replace(',', '.', $s);
-
-        return doubleval($s);
+        return ($this->type == Record::DBFFIELD_TYPE_NUMERIC && ($decimalCount > 0 || $length > 9)) 
+            ? doubleval($s)
+            : intval($s);
     }
 
     public function getIndex($columnName, $length)

--- a/src/XBase/Record.php
+++ b/src/XBase/Record.php
@@ -227,9 +227,14 @@ class Record
 
         $s = str_replace(',', '.', $s);
 
-        return ($this->type == Record::DBFFIELD_TYPE_NUMERIC && ($decimalCount > 0 || $length > 9)) 
-            ? doubleval($s)
-            : intval($s);
+        $column = $this->getColumn($columnName);
+
+        if ($column->type == Record::DBFFIELD_TYPE_NUMERIC &&
+            ($column->getDecimalCount() > 0 || $column->length > 9)
+        )
+            return doubleval($s);
+        else
+            return intval($s);
     }
 
     public function getIndex($columnName, $length)


### PR DESCRIPTION
Method Record::getInt renamed to Record::getNum and adapted for the case floating point numbers.

For backward compatibility you can do without renaming, but it will not match the semantics. 

You can also slightly improve performance move checking to Column::__ create, but it will require the introduction of additional property in Column - IMHO not worth the trouble against the background of file operations...