### PR TITLE
Changed decimalCount to be a public variable

### DIFF
--- a/src/XBase/Column.php
+++ b/src/XBase/Column.php
@@ -9,9 +9,9 @@ class Column
     public $rawname;
     public $type;
     public $length;
+    public $decimalCount;
 
     protected $memAddress;
-    protected $decimalCount;
     protected $workAreaID;
     protected $setFields;
     protected $indexed;


### PR DESCRIPTION
Users need access to the decimal count option when using this class to convert dbf to another db, so they know whether a column is an INT of DECIMAL or FLOAT.