### PR TITLE
Replaced flush with fflush

### DIFF
--- a/src/XBase/WritableTable.php
+++ b/src/XBase/WritableTable.php
@@ -145,7 +145,7 @@ class WritableTable extends Table
             $this->writeHeader();
         }
 
-        flush();
+        fflush($this->fp);
     }
 
     public function deleteRecord()
@@ -154,7 +154,7 @@ class WritableTable extends Table
         
         fseek($this->fp, $this->headerLength+($this->record->getRecordIndex()*$this->recordByteLength));
         fwrite($this->fp, "!");
-        flush();
+        fflush($this->fp);
     }
 
     public function undeleteRecord()
@@ -163,7 +163,7 @@ class WritableTable extends Table
         
         fseek($this->fp, $this->headerLength+($this->record->getRecordIndex()*$this->recordByteLength));
         fwrite($this->fp, " ");
-        flush();
+        fflush($this->fp);
     }
 
     public function pack()


### PR DESCRIPTION
I do not think it makes sense to use flush at the points below, since it flushes the output buffer to the HTTP server not to the file pointer.  I think the author wanted to use fflush on the file pointer.
It messed up serving zipped DBF files with CakePHP.